### PR TITLE
Krittapopkms/odd 39 fe item choosing component

### DIFF
--- a/src/components/ItemSelector/OneOutOfFourPicker/OneOutOfFourPicker.tsx
+++ b/src/components/ItemSelector/OneOutOfFourPicker/OneOutOfFourPicker.tsx
@@ -1,17 +1,19 @@
 "use client"
 import React, { useState } from "react";
 import QuestionBox from "../_QuestionBox/QuestionBox";
-import { Button } from "@/components/ui/button";
+// import { Button } from "@/components/ui/button";
+import Image from "next/image";
 import { cn } from "@/lib/utils";
 
 interface OneOutOfFourPickerProps {
     question: string;
-    options: string[];
+    srcs: string[];
+    onSelectionChange: (selectedIndex: number) => void;
 }
 
-export default function OneOutOfFourPicker({ question, options }: OneOutOfFourPickerProps) {
-    if (options.length !== 4) {
-        throw new Error("OneOutOfFourPicker requires exactly 4 options");
+export default function OneOutOfFourPicker({ question, srcs, onSelectionChange }: OneOutOfFourPickerProps) {
+    if (srcs.length !== 4) {
+        throw new Error("OneOutOfFourPicker requires exactly 4 srcs");
     }
 
     const [selected, setSelected] = useState<number[]>([]);
@@ -22,6 +24,7 @@ export default function OneOutOfFourPicker({ question, options }: OneOutOfFourPi
         } else if (selected.length < 1) {
             setSelected([...selected, index]);
         }
+        onSelectionChange(index);
     };
 
     return (
@@ -33,20 +36,21 @@ export default function OneOutOfFourPicker({ question, options }: OneOutOfFourPi
                 <div
                     className="grid grid-cols-2 gap-6 w-full bg-custom-light-gray rounded-xl px-12 py-6"
                 >
-                    {Object.entries(options).map(([index, option]) => (
-                        <Button
-                            className={cn(
-                                "w-full h-full aspect-square",
-                                Number(index) >= 2 ? "translate-x-6" : "-translate-x-6", // Options shifting
-                                selected.includes(Number(index)) ? "border-black border-4" : "", // Border on selected
-                                selected.length === 1 && !selected.includes(Number(index)) ? "blur-sm" : "", // Blur other options
-                            )}
-                            variant={"outline"}
-                            onClick={() => handleSelect(Number(index))}
+                    {Object.entries(srcs).map(([index, option]) => (
+                        <Image
                             key={index}
-                        >
-                            {option}
-                        </Button>
+                            src={option}
+                            alt={option}
+                            onClick={() => handleSelect(Number(index))}
+                            className={cn(
+                                "w-full h-full aspect-square cursor-pointer",
+                                Number(index) >= 2 ? "translate-x-6" : "-translate-x-6", // Images shifting
+                                selected.includes(Number(index)) ? "border-black border-4" : "", // Border on selected
+                                selected.length === 1 && !selected.includes(Number(index)) ? "blur-sm" : "", // Blur other Images
+                            )}
+                            width={200}
+                            height={200}
+                        />
                     ))}
                 </div>
             </div>

--- a/src/components/ItemSelector/OneOutOfFourPicker/OneOutOfFourPicker.tsx
+++ b/src/components/ItemSelector/OneOutOfFourPicker/OneOutOfFourPicker.tsx
@@ -8,23 +8,21 @@ import { cn } from "@/lib/utils";
 interface OneOutOfFourPickerProps {
     question: string;
     srcs: string[];
-    onSelectionChange: (selectedIndex: number) => void;
+    selected: number[];
+    onSelectionChange: (selectedIndex: number[]) => void;
 }
 
-export default function OneOutOfFourPicker({ question, srcs, onSelectionChange }: OneOutOfFourPickerProps) {
+export default function OneOutOfFourPicker({ question, srcs, selected, onSelectionChange }: OneOutOfFourPickerProps) {
     if (srcs.length !== 4) {
         throw new Error("OneOutOfFourPicker requires exactly 4 srcs");
     }
 
-    const [selected, setSelected] = useState<number[]>([]);
-
     const handleSelect = (index: number) => {
         if (selected.includes(index)) {
-            setSelected(selected.filter((i) => i !== index));
+            onSelectionChange(selected.filter((i) => i !== index));
         } else if (selected.length < 1) {
-            setSelected([...selected, index]);
+            onSelectionChange([...selected, index]);
         }
-        onSelectionChange(index);
     };
 
     return (

--- a/src/components/ItemSelector/OneOutOfFourPicker/OneOutOfFourPicker.tsx
+++ b/src/components/ItemSelector/OneOutOfFourPicker/OneOutOfFourPicker.tsx
@@ -1,0 +1,55 @@
+"use client"
+import React, { useState } from "react";
+import QuestionBox from "../_QuestionBox/QuestionBox";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface OneOutOfFourPickerProps {
+    question: string;
+    options: string[];
+}
+
+export default function OneOutOfFourPicker({ question, options }: OneOutOfFourPickerProps) {
+    if (options.length !== 4) {
+        throw new Error("OneOutOfFourPicker requires exactly 4 options");
+    }
+
+    const [selected, setSelected] = useState<number[]>([]);
+
+    const handleSelect = (index: number) => {
+        if (selected.includes(index)) {
+            setSelected(selected.filter((i) => i !== index));
+        } else if (selected.length < 1) {
+            setSelected([...selected, index]);
+        }
+    };
+
+    return (
+        <>
+            <div
+                className="flex flex-col gap-4"
+            >
+                <QuestionBox question={question} />
+                <div
+                    className="grid grid-cols-2 gap-6 w-full bg-custom-light-gray rounded-xl px-12 py-6"
+                >
+                    {Object.entries(options).map(([index, option]) => (
+                        <Button
+                            className={cn(
+                                "w-full h-full aspect-square",
+                                Number(index) >= 2 ? "translate-x-6" : "-translate-x-6", // Options shifting
+                                selected.includes(Number(index)) ? "border-black border-4" : "", // Border on selected
+                                selected.length === 1 && !selected.includes(Number(index)) ? "blur-sm" : "", // Blur other options
+                            )}
+                            variant={"outline"}
+                            onClick={() => handleSelect(Number(index))}
+                            key={index}
+                        >
+                            {option}
+                        </Button>
+                    ))}
+                </div>
+            </div>
+        </>
+    )
+};

--- a/src/components/ItemSelector/ThreeOutOfNinePicker/ThreeOutOfNinePicker.tsx
+++ b/src/components/ItemSelector/ThreeOutOfNinePicker/ThreeOutOfNinePicker.tsx
@@ -1,0 +1,54 @@
+"use client"
+import React, { useState } from "react";
+import QuestionBox from "../_QuestionBox/QuestionBox";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface ThreeOutOfNinePickerProps {
+    question: string;
+    options: string[];
+}
+
+export default function ThreeOutOfNinePicker({ question, options }: ThreeOutOfNinePickerProps) {
+    if (options.length !== 9) {
+        throw new Error("ThreeOutOfNinePicker requires exactly 9 options");
+    }
+
+    const [selected, setSelected] = useState<number[]>([]);
+
+    const handleSelect = (index: number) => {
+        if (selected.includes(index)) {
+            setSelected(selected.filter((i) => i !== index));
+        } else if (selected.length < 3) {
+            setSelected([...selected, index]);
+        }
+    };
+
+    return (
+        <>
+            <div
+                className="flex flex-col gap-4"
+            >
+                <QuestionBox question={question} />
+                <div
+                    className="grid grid-cols-3 gap-6 w-full bg-custom-light-gray rounded-xl p-6"
+                >
+                    {Object.entries(options).map(([index, option]) => (
+                        <Button
+                            className={cn(
+                                "w-full h-full aspect-square", 
+                                selected.includes(Number(index)) ? "border-black border-4" : "", // Border on selected
+                                selected.length === 3 && !selected.includes(Number(index)) ? "blur-sm" : "", // Blur other options
+                            )}
+                            variant={"outline"}
+                            onClick={() => handleSelect(Number(index))}
+                            key={index}
+                        >
+                            {option}
+                        </Button>
+                    ))}
+                </div>
+            </div>
+        </>
+    )
+};

--- a/src/components/ItemSelector/ThreeOutOfNinePicker/ThreeOutOfNinePicker.tsx
+++ b/src/components/ItemSelector/ThreeOutOfNinePicker/ThreeOutOfNinePicker.tsx
@@ -1,26 +1,26 @@
 "use client"
-import React, { useState } from "react";
+import React from "react";
 import QuestionBox from "../_QuestionBox/QuestionBox";
-import { Button } from "@/components/ui/button";
+import Image from "next/image";
 import { cn } from "@/lib/utils";
 
 interface ThreeOutOfNinePickerProps {
     question: string;
-    options: string[];
+    srcs: string[];
+    selected: number[];
+    onSelectionChange: (selectedIndex: number[]) => void;
 }
 
-export default function ThreeOutOfNinePicker({ question, options }: ThreeOutOfNinePickerProps) {
-    if (options.length !== 9) {
-        throw new Error("ThreeOutOfNinePicker requires exactly 9 options");
+export default function ThreeOutOfNinePicker({ question, srcs, selected, onSelectionChange }: ThreeOutOfNinePickerProps) {
+    if (srcs.length !== 9) {
+        throw new Error("ThreeOutOfNinePicker requires exactly 9 srcs");
     }
-
-    const [selected, setSelected] = useState<number[]>([]);
 
     const handleSelect = (index: number) => {
         if (selected.includes(index)) {
-            setSelected(selected.filter((i) => i !== index));
+            onSelectionChange(selected.filter((i) => i !== index));
         } else if (selected.length < 3) {
-            setSelected([...selected, index]);
+            onSelectionChange([...selected, index]);
         }
     };
 
@@ -33,19 +33,20 @@ export default function ThreeOutOfNinePicker({ question, options }: ThreeOutOfNi
                 <div
                     className="grid grid-cols-3 gap-6 w-full bg-custom-light-gray rounded-xl p-6"
                 >
-                    {Object.entries(options).map(([index, option]) => (
-                        <Button
-                            className={cn(
-                                "w-full h-full aspect-square", 
-                                selected.includes(Number(index)) ? "border-black border-4" : "", // Border on selected
-                                selected.length === 3 && !selected.includes(Number(index)) ? "blur-sm" : "", // Blur other options
-                            )}
-                            variant={"outline"}
-                            onClick={() => handleSelect(Number(index))}
+                    {Object.entries(srcs).map(([index, option]) => (
+                        <Image
                             key={index}
-                        >
-                            {option}
-                        </Button>
+                            src={option}
+                            alt={option}
+                            onClick={() => handleSelect(Number(index))}
+                            className={cn(
+                                "w-full h-full aspect-square cursor-pointer",
+                                selected.includes(Number(index)) ? "border-black border-4" : "", // Border on selected
+                                selected.length === 3 && !selected.includes(Number(index)) ? "blur-sm" : "", // Blur other Images
+                            )}
+                            width={200}
+                            height={200}
+                        />
                     ))}
                 </div>
             </div>

--- a/src/components/ItemSelector/_QuestionBox/QuestionBox.tsx
+++ b/src/components/ItemSelector/_QuestionBox/QuestionBox.tsx
@@ -1,0 +1,18 @@
+"use client"
+import React from "react";
+
+interface QuestionBoxProps {
+    question: string;
+}
+
+export default function QuestionBox({ question }: QuestionBoxProps) {
+    return (
+        <>
+            <div
+                className="w-full bg-custom-light-gray rounded-xl py-8 px-4 text-center"
+            >
+                {question}
+            </div>
+        </>
+    )
+}


### PR DESCRIPTION
## Issue ID/Name
https://linear.app/oddsnends/issue/ODD-39/[fe]-item-choosing-component
<!--Linear card ID-->

## Description
<!--What does this PR do? What is being changed, added, or removed? Does it introduce any breaking changes?-->
Created two types of Item choosing component.
9 item choosing component -> display 9 item and when user select 3 from 9 items all 6 other items will be blurred
4 item choosing component -> display 4 item and when user select 1 from 4 items all 3 other items will be blurred

## Checklist
<!--Put the 'X' inside the [] to check. Most of the time, everything should be checked.-->
- [X] I have self-reviewed my code.
- [X] I have commented on my code, particularly in the hard-to-understand area.
- [X] (Should Be) I have NOT committed the modified environment/config file(s) to this PR.
- [X] I have tagged a reviewer for this PR.

## Additional configuration/environment

## Screenshot(s)
1/4 unselected
![onefour_unselected](https://github.com/user-attachments/assets/6413e32e-f690-4dd4-a9a3-1100a49efe80)

1/4 selected
![onefour_selected](https://github.com/user-attachments/assets/03ef9ee1-c4e3-4f04-98bc-c2b84209ff86)

3/9 unselected
![threenine_unselected](https://github.com/user-attachments/assets/e41c5edb-a78f-4e17-8814-762d3b390904)

3/9 selected
![threenine_selected](https://github.com/user-attachments/assets/bde2570f-e7e1-4315-90ab-61e90211c92f)

## Reviewer
<!--Person who needs to review your PR-->
@LittleNa1000 

## Remark
<!--Further information about this PR-->
The components might appear quite large in the screenshot because I didn't add any margin. I left it that way so other developers can adjust the padding as needed when using it into their pages. For example:
![example_div_p](https://github.com/user-attachments/assets/55baab66-3f81-4077-add5-c2693d60605e)

But let me know if preset margin / padding is preferred over this